### PR TITLE
[FEATURE] Added parameter 'branch' 

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -1,0 +1,71 @@
+
+name: Clone Public Repository Workflow
+
+on:
+  push:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+    
+  job-public-repo-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Clone GuillaumeFalourd/poc-github-actions PUBLIC repository
+        uses: whyakari/github-repo-action@v3.1
+        with:
+          depth: 1
+          branch: 'main'
+          owner: 'GuillaumeFalourd'
+          repository: 'poc-github-actions'
+      
+      - name: Access cloned repository content
+        run: |
+          echo "ROOT"
+          ls -la
+          echo "CLONED REPO"
+          cd poc-github-actions
+          ls -la
+
+  job-public-repo-macos:
+    runs-on: macos-latest
+    steps:
+      
+      - name: Clone GuillaumeFalourd/poc-github-actions PUBLIC repository
+        uses: whyakari/github-repo-action@v3.1
+        with:
+          depth: 1
+          branch: 'main'
+          owner: 'GuillaumeFalourd'
+          repository: 'poc-github-actions'
+      
+      - name: Access cloned repository content
+        run: |
+          echo "ROOT"
+          ls -la
+          echo "CLONED REPO"
+          cd poc-github-actions
+          ls -la
+
+  job-public-repo-windows:
+    runs-on: windows-latest
+    steps:
+      
+      - name: Clone GuillaumeFalourd/poc-github-actions PUBLIC repository
+        uses: whyakari/clone-github-repo-action@main
+        with:
+          depth: 1
+          branch: 'main'
+          owner: 'GuillaumeFalourd'
+          repository: 'poc-github-actions'
+      
+      - name: Access cloned repository content
+        run: |
+          echo "ROOT"
+          ls -la
+          echo "CLONED REPO"
+          cd poc-github-actions
+          ls -la
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Field | Mandatory | Observation
 ------------ | ------------  | -------------
 **owner** | YES | Ex: `octocat`
 **repository** | YES | Ex: `clone-github-repo-action` | 
+**branch** | NO | 'main' Ex: clone branch main (default) if not defined arg
 **depth** | NO | 1 `Ex: most recent commit`
 **access-token** | NO | [How to create a PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)
 
@@ -37,6 +38,7 @@ You can use one of those as reference:
   uses: GuillaumeFalourd/clone-github-repo-action@v2.1
   with:
     depth: 1
+    branch: 'main'
     owner: 'GuillaumeFalourd'
     repository: 'poc-github-actions'
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Clone Github Repo Action'
+name: 'Clone Github Repo'
 
 description: "Github Action to clone a public or private Github repository and access its content on others repositories' workflows."
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Depth of the clone (default: full history)'
     required: false
     default: ""
+  branch:
+    description: 'Branch name (default: main)'
+    required: false
+    default: "main" 
 
 runs:
   using: 'composite'
@@ -24,21 +28,21 @@ runs:
       run: |
         if [ -z "${{ inputs.access-token }}" ]; then
           if [ -z "${{ inputs.depth }}" ]; then
-            git clone https://github.com/${{ inputs.owner }}/${{ inputs.repository }}.git
+            git clone --branch "${{ inputs.branch }}" https://github.com/${{ inputs.owner }}/${{ inputs.repository }}.git
           else
-            git clone --depth="${{ inputs.depth }}" https://github.com/${{ inputs.owner }}/${{ inputs.repository }}.git
+            git clone --branch "${{ inputs.branch }}" --depth="${{ inputs.depth }}" https://github.com/${{ inputs.owner }}/${{ inputs.repository }}.git
           fi
         else
           if [ -z "${{ inputs.depth }}" ]; then
-            git clone https://${{ inputs.access-token }}@github.com/${{ inputs.owner }}/${{ inputs.repository }}.git
+            git clone --branch "${{ inputs.branch }}" https://${{ inputs.access-token }}@github.com/${{ inputs.owner }}/${{ inputs.repository }}.git
           else
-            git clone --depth="${{ inputs.depth }}" https://${{ inputs.access-token }}@github.com/${{ inputs.owner }}/${{ inputs.repository }}.git
+            git clone --branch "${{ inputs.branch }}" --depth="${{ inputs.depth }}" https://${{ inputs.access-token }}@github.com/${{ inputs.owner }}/${{ inputs.repository }}.git
           fi
         fi
 
         if [ -d "${{ inputs.repository }}" ]; then
           echo "Cloned ${{ inputs.repository }} repository successfully."
-          echo "Access the repository content using \"cd ${{ inputs.repository }}\"." 
+          echo "Access the repository content using \"cd ${{ inputs.repository }}.\""
         else
           echo "Error: Couldn't clone ${{ inputs.repository }} repository. Check the inputs or the PAT scope."
           exit 1
@@ -48,3 +52,4 @@ runs:
 branding:
   icon: 'download'
   color: 'blue'
+


### PR DESCRIPTION
In some cases, the branch is not always the default (main, master). now being able to specify the desired branch:

Ex:
```
- name: Clone GuillaumeFalourd/poc-github-actions PUBLIC repository
  uses: GuillaumeFalourd/clone-github-repo-action@v2.1
  with:
    depth: 1
    branch: 'main'
    owner: 'GuillaumeFalourd'
    repository: 'poc-github-actions'
```